### PR TITLE
Add default tokenizer type protocol

### DIFF
--- a/Documentation/Literal tokenizer.md
+++ b/Documentation/Literal tokenizer.md
@@ -16,12 +16,7 @@ class LiteralTokenizer: TokenizerType {
     private let target: String
     private var position: String.UnicodeScalarIndex
 
-    // required by the TokenizerType protocol, but non-sensical to use
-    required convenience init() {
-        self.init(target: "")
-    }
-
-    // instead, we should initialize instance with the target String we're looking for
+    // initialize a tokenizer with the target String we're looking for
     init(target: String) {
         self.target = target
         self.position = target.unicodeScalars.startIndex
@@ -101,4 +96,4 @@ for token in tokens {
 
 ````
 
-See [FuzzyMatchTokenTests.swift](/Mustard/MustardTests/FuzzyMatchTokenTests.swift) for a unit test that includes matching a literal String, but allowing some flexibility in the literal match by ignoring certain characters. 
+See [FuzzyMatchTokenTests.swift](/Mustard/MustardTests/FuzzyMatchTokenTests.swift) for a unit test that includes matching a literal String, but allowing some flexibility in the literal match by ignoring certain characters.

--- a/Documentation/Template tokenizer.md
+++ b/Documentation/Template tokenizer.md
@@ -17,7 +17,7 @@ func ~= (option: CharacterSet, input: UnicodeScalar) -> Bool {
     return option.contains(input)
 }
 
-class DateTokenizer: TokenizerType {
+class DateTokenizer: TokenizerType, DefaultTokenizerType {
 
     // private properties
     private let _template = "00/00/00"

--- a/Mustard/Mustard/CharacterSet+Mustard.swift
+++ b/Mustard/Mustard/CharacterSet+Mustard.swift
@@ -22,7 +22,7 @@
 
 import Foundation
 
-extension CharacterSet: TokenizerType {
+extension CharacterSet: TokenizerType, DefaultTokenizerType {
     public func tokenCanTake(_ scalar: UnicodeScalar) -> Bool {
         return self.contains(scalar)
     }

--- a/Mustard/Mustard/Mustard.swift
+++ b/Mustard/Mustard/Mustard.swift
@@ -49,9 +49,18 @@ public extension String {
     /// instead.
     ///
     /// Returns: An array of type `TokenizerType.Token`.
-    func tokens<T: TokenizerType>() -> [(tokenizer: T, text: String, range: Range<String.Index>)] {
+    func tokens<T: DefaultTokenizerType>() -> [(tokenizer: T, text: String, range: Range<String.Index>)] {
         
-        return self.tokens(matchedWith: T()).flatMap({
+        return self.tokens(matchedWith: T.defaultTokenzier).flatMap({
+            if let tokenizer = $0.tokenizer as? T {
+                return (tokenizer: tokenizer, text: $0.text, range: $0.range)
+            }
+            else { return nil }
+        })
+    }
+    
+    func tokens<T: TokenizerType>(matchedWith tokenizers: T...) -> [(tokenizer: T, text: String, range: Range<String.Index>)] {
+        return self.tokens(from: tokenizers).flatMap({
             if let tokenizer = $0.tokenizer as? T {
                 return (tokenizer: tokenizer, text: $0.text, range: $0.range)
             }

--- a/Mustard/Mustard/TokenizerType.swift
+++ b/Mustard/Mustard/TokenizerType.swift
@@ -29,6 +29,7 @@ import Foundation
 /// - range: The range of the matched text in the original string.
 public typealias Token = (tokenizer: TokenizerType, text: String, range: Range<String.Index>)
 
+/// Defines the implementation needed to create a tokenizer for use with Mustard.
 public protocol TokenizerType {
     
     /// Returns an instance of a tokenizer that starts with the given scalar,
@@ -87,9 +88,6 @@ public protocol TokenizerType {
     /// `tokenCanTake(_:)`
     func prepareForReuse()
     
-    /// Initialize an empty instance of the tokenizer.
-    init()
-    
     /// Returns an instance of the tokenizer that will be used as the `tokenizer` element in the `Token` tuple.
     ///
     /// If the tokenizer implements `NSCopying` protocol, the default implementation returns the result of
@@ -97,6 +95,20 @@ public protocol TokenizerType {
     /// 
     /// Provide an alternate implementation if the tokenizer is a reference type that does not implement `NSCopying`.
     var tokenizerForMatch: TokenizerType { get }
+}
+
+/// Defines the implementation needed for a TokenizerType to have some convenience methods
+/// enabled when the tokenizer has a default initializer.
+public protocol DefaultTokenizerType: TokenizerType {
+    
+    /// Initialize an empty instance of the tokenizer.
+    init()
+}
+
+extension DefaultTokenizerType {
+    /// The default tokenzier for this type.
+    /// This is equivilent to using the default initalizer `init()`.
+    public static var defaultTokenzier: DefaultTokenizerType { return Self() }
 }
 
 public extension TokenizerType {
@@ -107,10 +119,6 @@ public extension TokenizerType {
     /// - text: A substring that the tokenizer matched in the original string.
     /// - range: The range of the matched text in the original string.
     typealias Token = (tokenizer: Self, text: String, range: Range<String.Index>)
-    
-    /// The default tokenzier for this type.
-    /// This is equivilent to using the default initalizer `init()`.
-    static var defaultTokenzier: TokenizerType { return Self() }
     
     func tokenCanStart(with scalar: UnicodeScalar) -> Bool {
         return tokenCanTake(scalar)

--- a/Mustard/MustardTests/CharacterSetTokenTests.swift
+++ b/Mustard/MustardTests/CharacterSetTokenTests.swift
@@ -35,7 +35,7 @@ class CharacterSetTokenTests: XCTestCase {
     
     func testCharacterSetTokenizer() {
                 
-        let tokens = "123Hello world&^45.67".tokens(matchedWith: .decimalDigits, .letters)
+        let tokens: [CharacterSet.Token] = "123Hello world&^45.67".tokens(matchedWith: .decimalDigits, .letters)
         
         XCTAssert(tokens.count == 5, "Unexpected number of tokens [\(tokens.count)]")
         

--- a/Mustard/MustardTests/CustomTokenTests.swift
+++ b/Mustard/MustardTests/CustomTokenTests.swift
@@ -23,7 +23,7 @@
 import XCTest
 import Mustard
 
-struct NumberTokenizer: TokenizerType {
+struct NumberTokenizer: TokenizerType, DefaultTokenizerType {
     
     static private let numberCharacters = CharacterSet.decimalDigits.union(CharacterSet(charactersIn: "."))
     
@@ -38,7 +38,7 @@ struct NumberTokenizer: TokenizerType {
     }
 }
 
-struct WordTokenizer: TokenizerType {
+struct WordTokenizer: TokenizerType, DefaultTokenizerType {
 
     // word token can include any character in a...z + A...Z
     func tokenCanTake(_ scalar: UnicodeScalar) -> Bool {

--- a/Mustard/MustardTests/DateTokenizerTests.swift
+++ b/Mustard/MustardTests/DateTokenizerTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 import Mustard
 
-class DateTokenizer: TokenizerType {
+class DateTokenizer: TokenizerType, DefaultTokenizerType {
     
     // private properties
     private let _template = "00/00/00"
@@ -22,18 +22,18 @@ class DateTokenizer: TokenizerType {
         return _date!
     }
     
+    // called when we access `DateToken.defaultTokenizer`
+    required init() {
+        _position = _template.unicodeScalars.startIndex
+        _dateText = ""
+    }
+    
     // formatters are expensive, so only instantiate once for all DateTokens
     static let dateFormatter: DateFormatter = {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "MM/dd/yy"
         return dateFormatter
     }()
-    
-    // called when we access `DateToken.tokenizer`
-    required init() {
-        _position = _template.unicodeScalars.startIndex
-        _dateText = ""
-    }
     
     func tokenCanTake(_ scalar: UnicodeScalar) -> Bool {
         

--- a/Mustard/MustardTests/EmojiTokenTests.swift
+++ b/Mustard/MustardTests/EmojiTokenTests.swift
@@ -23,7 +23,7 @@
 import XCTest
 import Mustard
 
-struct EmojiTokenizer: TokenizerType {
+struct EmojiTokenizer: TokenizerType, DefaultTokenizerType {
     
     // (e.g. can't start with a ZWJ)
     func tokenCanStart(with scalar: UnicodeScalar) -> Bool {

--- a/Mustard/MustardTests/FuzzyMatchTokenTests.swift
+++ b/Mustard/MustardTests/FuzzyMatchTokenTests.swift
@@ -34,10 +34,6 @@ class FuzzyLiteralMatch: TokenizerType {
     private let exclusions: CharacterSet
     private var position: String.UnicodeScalarIndex
     
-    required convenience init() {
-        self.init(target: "", ignoring: CharacterSet.whitespaces)
-    }
-    
     init(target: String, ignoring exclusions: CharacterSet) {
         self.target = target
         self.position = target.unicodeScalars.startIndex
@@ -101,11 +97,9 @@ class FuzzyMatchTokenTests: XCTestCase {
                                                ignoring: CharacterSet.whitespaces.union(.punctuationCharacters))
         
         let messyInput = "Serial: #YF 1942-b 12/01/27 (Scanned) 12/02/27 (Arrived) ref: 99/99/99"
-        let tokens = messyInput.tokens(matchedWith: fuzzyTokenzier)
+        let tokens: [FuzzyLiteralMatch.Token] = messyInput.tokens(matchedWith: fuzzyTokenzier)
         
         XCTAssert(tokens.count == 1, "Unexpected number of tokens [\(tokens.count)]")
-        
-        XCTAssert(tokens[0].tokenizer is FuzzyLiteralMatch)
         XCTAssert(tokens[0].text == "#YF 1942-b")
     }
 }

--- a/Mustard/MustardTests/LiteralTokenTests.swift
+++ b/Mustard/MustardTests/LiteralTokenTests.swift
@@ -29,11 +29,6 @@ class LiteralTokenizer: TokenizerType {
     private let target: String
     private var position: String.UnicodeScalarIndex
     
-    // required by the TokenType protocol, but non-sensical to use
-    required convenience init() {
-        self.init(target: "")
-    }
-    
     // instead, we should initalize instance with the target String we're looking for
     init(target: String) {
         self.target = target
@@ -91,21 +86,16 @@ extension String {
     }
 }
 
-
 class LiteralTokenTests: XCTestCase {
     
     func testGetCatAndDuck() {
         
         let input = "the cat and the catastrophe duck"
-        let tokens = input.tokens(matchedWith: "cat".literalTokenizer, "duck".literalTokenizer)
+        let tokens: [LiteralTokenizer.Token] = input.tokens(matchedWith: "cat".literalTokenizer, "duck".literalTokenizer)
         
         XCTAssert(tokens.count == 2, "Unexpected number of tokens [\(tokens.count)]")
         
-        XCTAssert(tokens[0].tokenizer is LiteralTokenizer)
         XCTAssert(tokens[0].text == "cat")
-        
-        XCTAssert(tokens[1].tokenizer is LiteralTokenizer)
         XCTAssert(tokens[1].text == "duck")
-        
     }
 }

--- a/Mustard/MustardTests/MixedTokenTests.swift
+++ b/Mustard/MustardTests/MixedTokenTests.swift
@@ -23,7 +23,7 @@
 import XCTest
 import Mustard
 
-enum MixedTokenizer: TokenizerType {
+enum MixedTokenizer: TokenizerType, DefaultTokenizerType {
     
     case word
     case number

--- a/Playgrounds/Source/CharacterSet Tokenizers.playground/Contents.swift
+++ b/Playgrounds/Source/CharacterSet Tokenizers.playground/Contents.swift
@@ -7,13 +7,19 @@ Note: To use framework in a playground, the playground must be opened in a works
 import Foundation
 import Mustard
 
+struct NumberTokenizer: TokenizerType {
+    func tokenCanTake(_ scalar: UnicodeScalar) -> Bool {
+        return true
+    }
+}
+
 let str = "Hello, playground 2017"
 
 let words = str.components(matchedWith: .letters)
 // words.count -> 2
 // words = ["hello", "playground"]
 
-let tokens = "123Hello world&^45.67".tokens(matchedWith: .decimalDigits, .letters)
+let tokens: [CharacterSet.Token] = "123Hello world&^45.67".tokens(matchedWith: .decimalDigits, .letters)
 
 for token in tokens {
     switch token.tokenizer {
@@ -25,3 +31,6 @@ for token in tokens {
     default: break
     }
 }
+
+let numberTokens = tokens.filter({ $0.tokenizer is NumberTokenizer })
+// numberTokens.count -> 0


### PR DESCRIPTION
The `DefaultTokenizerType` separates out the requirement for a default initializer from the core `TokenizerType` protocol.

This means that tokenizers like the `LiteralTokenizer` don't require an initializer when it doesn't really make sense.

Also included an alternate tokens method that can be used when all the tokenizers are the same type: `tokens<T: TokenizerType>(matchedWith tokenizers: T...)` this tuple of matches that is returned is strongly typed to the single tokenizer that was used that provides more safety when using this method.